### PR TITLE
fix: Mono.Cecil version conflicts with Mono.Cecil

### DIFF
--- a/BepInEx.Core/BepInEx.Core.csproj
+++ b/BepInEx.Core/BepInEx.Core.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All"/>
         <PackageReference Include="SemanticVersioning" Version="2.0.2"/>
         <PackageReference Include="MonoMod.Utils" Version="25.0.8"/>
+        <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     </ItemGroup>
     <ItemGroup>
         <Compile Remove="Contract\IPlugin.cs"/>


### PR DESCRIPTION
Right now we get fuck ton of warnings in downstream when we try to build mods. This overwrites the Mono.Cecil version to match the same one that Resonite uses.


https://github.com/user-attachments/assets/3bcfea0e-4c12-4644-8a3a-4df270db0508

