### PR TITLE
fix: change HarmonyX submodule to a different repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "HarmonyX"]
 	path = HarmonyX
-	url = https://github.com/art0007i/HarmonyX/
+	url = https://github.com/ResoniteModding/HarmonyX.git
+	branch = patchy


### PR DESCRIPTION
Changed the submodule to the org's fork and also this uses [patchy](https://github.com/nik-rev/patchy) now. So if we want to pull PRs, branches or patches, we can easily do that by modifying `.patchy/config.toml` and then running `patchy run` locally and pushing the updated branch.